### PR TITLE
(fix): Add info to cv_params for new MiplessCloudVolumes

### DIFF
--- a/corgie/mipless_cloudvolume.py
+++ b/corgie/mipless_cloudvolume.py
@@ -52,6 +52,8 @@ class MiplessCloudVolume():
         self.cv_params = {}
         if 'cv_params' in kwargs:
             self.cv_params.update(kwargs['cv_params'])
+        if 'info' in kwargs:
+            self.cv_params['info'] = kwargs['info']
         self.cv_params.setdefault('bounded', False)
         self.cv_params.setdefault('progress', False)
         self.cv_params.setdefault('autocrop', False)


### PR DESCRIPTION
In feature to add cv_params to MiplessCloudVolume, info files were removed, preventing new CloudVolumes from being created.